### PR TITLE
add name of the license of the firmware

### DIFF
--- a/firmware/LICENSE
+++ b/firmware/LICENSE
@@ -1,3 +1,5 @@
+  Icedev Zero Firmware is available under the zlib license:
+  
   Copyright (C) 2024-2025 Cheyao 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages


### PR DESCRIPTION
I've added the name of the license in the firmware directory, so it's more clear what the license is.